### PR TITLE
Suppress time_t musl "deprecation"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,6 +395,8 @@ impl VsockStream {
                     ));
                 }
 
+                // https://github.com/rust-lang/libc/issues/1848
+                #[cfg_attr(target_env = "musl", allow(deprecated))]
                 let secs = if dur.as_secs() > time_t::max_value() as u64 {
                     time_t::max_value()
                 } else {


### PR DESCRIPTION
See rust-lang/libc#1848 in which this type is
changing from i32 to i64; the change is being announced via this
deprecation.

Signed-off-by: Tim Zhang <tim@hyper.sh>