### PR TITLE
Update nix package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["test_fixture"]
 
 [dependencies]
 libc = "0.2.79"
-nix = "0.22.1"
+nix = "0.23.0"
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
0.23.0 fixed an issue https://github.com/nix-rust/nix/pull/1545,
that `cargo deny check advisories` will fail if using the old version
of nix package.