### PR TITLE
Update to nix 0.24.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["test_fixture"]
 
 [dependencies]
 libc = "0.2.79"
-nix = "0.23.0"
+nix = "0.24.1"
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/echo_server/src/main.rs
+++ b/echo_server/src/main.rs
@@ -19,7 +19,7 @@ use std::io::Read;
 use std::io::Write;
 use std::net::Shutdown;
 use std::thread;
-use vsock::{SockAddr, VsockAddr, VsockListener};
+use vsock::{VsockAddr, VsockListener};
 
 const BLOCK_SIZE: usize = 16384;
 
@@ -48,11 +48,8 @@ fn main() {
         .parse::<u32>()
         .expect("port must be a valid integer");
 
-    let listener = VsockListener::bind(&SockAddr::Vsock(VsockAddr::new(
-        libc::VMADDR_CID_ANY,
-        listen_port,
-    )))
-    .expect("bind and listen failed");
+    let listener = VsockListener::bind(&VsockAddr::new(libc::VMADDR_CID_ANY, listen_port))
+        .expect("bind and listen failed");
 
     println!("Server listening for connections on port {}", listen_port);
     for stream in listener.incoming() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl VsockListener {
     /// Create a new VsockListener which is bound and listening on the socket address.
     pub fn bind(addr: &SockAddr) -> Result<VsockListener> {
         let mut vsock_addr = if let SockAddr::Vsock(addr) = addr {
-            addr.0
+            addr.as_ref().to_owned()
         } else {
             return Err(Error::new(
                 ErrorKind::Other,
@@ -116,7 +116,10 @@ impl VsockListener {
         {
             Err(Error::last_os_error())
         } else {
-            Ok(SockAddr::Vsock(VsockAddr(vsock_addr)))
+            Ok(SockAddr::Vsock(VsockAddr::new(
+                vsock_addr.svm_cid,
+                vsock_addr.svm_port,
+            )))
         }
     }
 
@@ -229,7 +232,7 @@ impl VsockStream {
     /// Open a connection to a remote host.
     pub fn connect(addr: &SockAddr) -> Result<Self> {
         let vsock_addr = if let SockAddr::Vsock(addr) = addr {
-            addr.0
+            addr.as_ref()
         } else {
             return Err(Error::new(
                 ErrorKind::Other,
@@ -244,7 +247,7 @@ impl VsockStream {
         if unsafe {
             connect(
                 sock,
-                &vsock_addr as *const _ as *const sockaddr,
+                vsock_addr as *const _ as *const sockaddr,
                 size_of::<sockaddr_vm>() as socklen_t,
             )
         } < 0
@@ -280,7 +283,10 @@ impl VsockStream {
         {
             Err(Error::last_os_error())
         } else {
-            Ok(SockAddr::Vsock(VsockAddr(vsock_addr)))
+            Ok(SockAddr::Vsock(VsockAddr::new(
+                vsock_addr.svm_cid,
+                vsock_addr.svm_port,
+            )))
         }
     }
 
@@ -304,7 +310,10 @@ impl VsockStream {
         {
             Err(Error::last_os_error())
         } else {
-            Ok(SockAddr::Vsock(VsockAddr(vsock_addr)))
+            Ok(SockAddr::Vsock(VsockAddr::new(
+                vsock_addr.svm_cid,
+                vsock_addr.svm_port,
+            )))
         }
     }
 

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -17,7 +17,7 @@
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::io::{Read, Write};
-use vsock::{get_local_cid, SockAddr, VsockAddr, VsockStream, VMADDR_CID_HOST};
+use vsock::{get_local_cid, VsockAddr, VsockStream, VMADDR_CID_HOST};
 
 const TEST_BLOB_SIZE: usize = 1_000_000;
 const TEST_BLOCK_SIZE: usize = 5_000;
@@ -39,8 +39,7 @@ fn test_vsock() {
     rx_blob.resize(TEST_BLOB_SIZE, 0);
     rng.fill_bytes(&mut blob);
 
-    let mut stream =
-        VsockStream::connect(&SockAddr::Vsock(VsockAddr::new(3, 8000))).expect("connection failed");
+    let mut stream = VsockStream::connect(&VsockAddr::new(3, 8000)).expect("connection failed");
 
     while tx_pos < TEST_BLOB_SIZE {
         let written_bytes = stream


### PR DESCRIPTION
This makes the contents of `VsockAddr` private, so we have to use the provided methods instead. This is an API-breaking change.

Fixes #24.