### PR TITLE
Use nix wrappers where possible.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,12 @@
 
 //! Virtio socket support for Rust.
 
-use libc::*;
+use libc::{
+    accept4, bind, close, connect, getpeername, getsockname, getsockopt, ioctl, listen, recv,
+    sa_family_t, send, setsockopt, shutdown, sockaddr, sockaddr_vm, socket, socklen_t, suseconds_t,
+    timeval, AF_VSOCK, FIONBIO, MSG_NOSIGNAL, SHUT_RD, SHUT_RDWR, SHUT_WR, SOCK_CLOEXEC,
+    SOCK_STREAM, SOL_SOCKET, SO_ERROR, SO_RCVTIMEO, SO_SNDTIMEO,
+};
 use nix::{ioctl_read_bad, sys::socket::AddressFamily};
 use std::ffi::c_void;
 use std::fs::File;
@@ -394,10 +399,10 @@ impl VsockStream {
 
                 // https://github.com/rust-lang/libc/issues/1848
                 #[cfg_attr(target_env = "musl", allow(deprecated))]
-                let secs = if dur.as_secs() > time_t::max_value() as u64 {
-                    time_t::max_value()
+                let secs = if dur.as_secs() > libc::time_t::max_value() as u64 {
+                    libc::time_t::max_value()
                 } else {
-                    dur.as_secs() as time_t
+                    dur.as_secs() as libc::time_t
                 };
                 let mut timeout = timeval {
                     tv_sec: secs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ impl IntoRawFd for VsockListener {
 
 impl Drop for VsockListener {
     fn drop(&mut self) {
-        _ = close(self.socket);
+        let _ = close(self.socket);
     }
 }
 
@@ -412,7 +412,7 @@ impl IntoRawFd for VsockStream {
 
 impl Drop for VsockStream {
     fn drop(&mut self) {
-        _ = close(self.socket);
+        let _ = close(self.socket);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,13 +18,18 @@
 //! Virtio socket support for Rust.
 
 use libc::{
-    accept4, bind, close, connect, getpeername, getsockname, getsockopt, ioctl, listen, recv,
-    sa_family_t, send, setsockopt, shutdown, sockaddr, sockaddr_vm, socket, socklen_t, suseconds_t,
-    timeval, AF_VSOCK, FIONBIO, MSG_NOSIGNAL, SHUT_RD, SHUT_RDWR, SHUT_WR, SOCK_CLOEXEC,
-    SOCK_STREAM, SOL_SOCKET, SO_ERROR, SO_RCVTIMEO, SO_SNDTIMEO,
+    accept4, getpeername, getsockname, ioctl, sa_family_t, sockaddr, sockaddr_vm, socklen_t,
+    suseconds_t, timeval, AF_VSOCK, FIONBIO, SOCK_CLOEXEC,
 };
-use nix::{ioctl_read_bad, sys::socket::AddressFamily};
-use std::ffi::c_void;
+use nix::{
+    ioctl_read_bad,
+    sys::socket::{
+        self, bind, connect, listen, recv, send, shutdown, socket,
+        sockopt::{ReceiveTimeout, SendTimeout, SocketError},
+        AddressFamily, GetSockOpt, MsgFlags, SetSockOpt, SockFlag, SockType,
+    },
+    unistd::close,
+};
 use std::fs::File;
 use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::mem::{self, size_of};
@@ -35,8 +40,13 @@ use std::time::Duration;
 pub use libc::{VMADDR_CID_ANY, VMADDR_CID_HOST, VMADDR_CID_HYPERVISOR, VMADDR_CID_LOCAL};
 pub use nix::sys::socket::{SockaddrLike, VsockAddr};
 
-fn new_socket() -> libc::c_int {
-    unsafe { socket(AF_VSOCK, SOCK_STREAM | SOCK_CLOEXEC, 0) }
+fn new_socket() -> Result<RawFd> {
+    Ok(socket(
+        AddressFamily::Vsock,
+        SockType::Stream,
+        SockFlag::SOCK_CLOEXEC,
+        None,
+    )?)
 }
 
 /// An iterator that infinitely accepts connections on a VsockListener.
@@ -69,21 +79,12 @@ impl VsockListener {
             ));
         }
 
-        let socket = new_socket();
-        if socket < 0 {
-            return Err(Error::last_os_error());
-        }
+        let socket = new_socket()?;
 
-        let res = unsafe { bind(socket, addr.as_ptr(), addr.len()) };
-        if res < 0 {
-            return Err(Error::last_os_error());
-        }
+        bind(socket, addr)?;
 
         // rust stdlib uses a 128 connection backlog
-        let res = unsafe { listen(socket, 128) };
-        if res < 0 {
-            return Err(Error::last_os_error());
-        }
+        listen(socket, 128)?;
 
         Ok(Self { socket })
     }
@@ -157,26 +158,12 @@ impl VsockListener {
 
     /// Retrieve the latest error associated with the underlying socket.
     pub fn take_error(&self) -> Result<Option<Error>> {
-        let mut error: i32 = 0;
-        let mut error_len: socklen_t = 0;
-        if unsafe {
-            getsockopt(
-                self.socket,
-                SOL_SOCKET,
-                SO_ERROR,
-                &mut error as *mut _ as *mut c_void,
-                &mut error_len,
-            )
-        } < 0
-        {
-            Err(Error::last_os_error())
+        let error = SocketError.get(self.socket)?;
+        Ok(if error == 0 {
+            None
         } else {
-            Ok(if error == 0 {
-                None
-            } else {
-                Some(Error::from_raw_os_error(error))
-            })
-        }
+            Some(Error::from_raw_os_error(error))
+        })
     }
 
     /// Move this stream in and out of nonblocking mode.
@@ -212,7 +199,7 @@ impl IntoRawFd for VsockListener {
 
 impl Drop for VsockListener {
     fn drop(&mut self) {
-        unsafe { close(self.socket) };
+        _ = close(self.socket);
     }
 }
 
@@ -232,15 +219,9 @@ impl VsockStream {
             ));
         }
 
-        let sock = new_socket();
-        if sock < 0 {
-            return Err(Error::last_os_error());
-        }
-        if unsafe { connect(sock, addr.as_ptr(), addr.len()) } < 0 {
-            Err(Error::last_os_error())
-        } else {
-            Ok(unsafe { Self::from_raw_fd(sock) })
-        }
+        let sock = new_socket()?;
+        connect(sock, addr)?;
+        Ok(unsafe { Self::from_raw_fd(sock) })
     }
 
     /// Open a connection to a remote host with specified cid and port.
@@ -299,15 +280,11 @@ impl VsockStream {
     /// Shutdown the read, write, or both halves of this connection.
     pub fn shutdown(&self, how: Shutdown) -> Result<()> {
         let how = match how {
-            Shutdown::Write => SHUT_WR,
-            Shutdown::Read => SHUT_RD,
-            Shutdown::Both => SHUT_RDWR,
+            Shutdown::Write => socket::Shutdown::Write,
+            Shutdown::Read => socket::Shutdown::Read,
+            Shutdown::Both => socket::Shutdown::Both,
         };
-        if unsafe { shutdown(self.socket, how) } < 0 {
-            Err(Error::last_os_error())
-        } else {
-            Ok(())
-        }
+        Ok(shutdown(self.socket, how)?)
     }
 
     /// Create a new independently owned handle to the underlying socket.
@@ -317,64 +294,24 @@ impl VsockStream {
 
     /// Set the timeout on read operations.
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
-        let timeout = Self::timeval_from_duration(dur)?;
-        if unsafe {
-            setsockopt(
-                self.socket,
-                SOL_SOCKET,
-                SO_SNDTIMEO,
-                &timeout as *const _ as *const c_void,
-                size_of::<timeval>() as socklen_t,
-            )
-        } < 0
-        {
-            Err(Error::last_os_error())
-        } else {
-            Ok(())
-        }
+        let timeout = Self::timeval_from_duration(dur)?.into();
+        Ok(SendTimeout.set(self.socket, &timeout)?)
     }
 
     /// Set the timeout on write operations.
     pub fn set_write_timeout(&self, dur: Option<Duration>) -> Result<()> {
-        let timeout = Self::timeval_from_duration(dur)?;
-        if unsafe {
-            setsockopt(
-                self.socket,
-                SOL_SOCKET,
-                SO_RCVTIMEO,
-                &timeout as *const _ as *const c_void,
-                size_of::<timeval>() as socklen_t,
-            )
-        } < 0
-        {
-            Err(Error::last_os_error())
-        } else {
-            Ok(())
-        }
+        let timeout = Self::timeval_from_duration(dur)?.into();
+        Ok(ReceiveTimeout.set(self.socket, &timeout)?)
     }
 
     /// Retrieve the latest error associated with the underlying socket.
     pub fn take_error(&self) -> Result<Option<Error>> {
-        let mut error: i32 = 0;
-        let mut error_len: socklen_t = 0;
-        if unsafe {
-            getsockopt(
-                self.socket,
-                SOL_SOCKET,
-                SO_ERROR,
-                &mut error as *mut _ as *mut c_void,
-                &mut error_len,
-            )
-        } < 0
-        {
-            Err(Error::last_os_error())
+        let error = SocketError.get(self.socket)?;
+        Ok(if error == 0 {
+            None
         } else {
-            Ok(if error == 0 {
-                None
-            } else {
-                Some(Error::from_raw_os_error(error))
-            })
-        }
+            Some(Error::from_raw_os_error(error))
+        })
     }
 
     /// Move this stream in and out of nonblocking mode.
@@ -439,30 +376,13 @@ impl Write for VsockStream {
 
 impl Read for &VsockStream {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let ret = unsafe { recv(self.socket, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) };
-        if ret < 0 {
-            Err(Error::last_os_error())
-        } else {
-            Ok(ret as usize)
-        }
+        Ok(recv(self.socket, buf, MsgFlags::empty())?)
     }
 }
 
 impl Write for &VsockStream {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let ret = unsafe {
-            send(
-                self.socket,
-                buf.as_ptr() as *const c_void,
-                buf.len(),
-                MSG_NOSIGNAL,
-            )
-        };
-        if ret < 0 {
-            Err(Error::last_os_error())
-        } else {
-            Ok(ret as usize)
-        }
+        Ok(send(self.socket, buf, MsgFlags::MSG_NOSIGNAL)?)
     }
 
     fn flush(&mut self) -> Result<()> {
@@ -492,7 +412,7 @@ impl IntoRawFd for VsockStream {
 
 impl Drop for VsockStream {
     fn drop(&mut self) {
-        unsafe { close(self.socket) };
+        _ = close(self.socket);
     }
 }
 

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -92,7 +92,9 @@ fn test_stream_addresses() {
         VsockStream::connect(&VsockAddr::new(SERVER_CID, SERVER_PORT)).expect("connection failed");
 
     let local_addr = stream.local_addr().unwrap();
-    assert_eq!(local_addr.cid(), libc::VMADDR_CID_ANY);
+    // Apparently on some systems a client socket has the host CID, on some it has CID_ANY. Allow
+    // either.
+    assert!([libc::VMADDR_CID_ANY, VMADDR_CID_HOST].contains(&local_addr.cid()));
 
     let peer_addr = stream.peer_addr().unwrap();
     assert_eq!(peer_addr.cid(), SERVER_CID);

--- a/tests/vsock.rs
+++ b/tests/vsock.rs
@@ -17,10 +17,14 @@
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use std::io::{Read, Write};
-use vsock::{get_local_cid, VsockAddr, VsockStream, VMADDR_CID_HOST};
+use vsock::{get_local_cid, VsockAddr, VsockListener, VsockStream, VMADDR_CID_HOST};
 
 const TEST_BLOB_SIZE: usize = 1_000_000;
 const TEST_BLOCK_SIZE: usize = 5_000;
+
+const SERVER_CID: u32 = 3;
+const SERVER_PORT: u32 = 8000;
+const LISTEN_PORT: u32 = 9000;
 
 /// A simple test for the vsock implementation.
 /// Generate a large random blob of binary data, and transfer it in chunks over the VsockStream
@@ -39,7 +43,8 @@ fn test_vsock() {
     rx_blob.resize(TEST_BLOB_SIZE, 0);
     rng.fill_bytes(&mut blob);
 
-    let mut stream = VsockStream::connect(&VsockAddr::new(3, 8000)).expect("connection failed");
+    let mut stream =
+        VsockStream::connect(&VsockAddr::new(SERVER_CID, SERVER_PORT)).expect("connection failed");
 
     while tx_pos < TEST_BLOB_SIZE {
         let written_bytes = stream
@@ -70,4 +75,26 @@ fn test_vsock() {
 #[test]
 fn test_get_local_cid() {
     assert_eq!(get_local_cid().unwrap(), VMADDR_CID_HOST);
+}
+
+#[test]
+fn test_listener_local_addr() {
+    let listener = VsockListener::bind(&VsockAddr::new(VMADDR_CID_HOST, LISTEN_PORT)).unwrap();
+
+    let local_addr = listener.local_addr().unwrap();
+    assert_eq!(local_addr.cid(), VMADDR_CID_HOST);
+    assert_eq!(local_addr.port(), LISTEN_PORT);
+}
+
+#[test]
+fn test_stream_addresses() {
+    let stream =
+        VsockStream::connect(&VsockAddr::new(SERVER_CID, SERVER_PORT)).expect("connection failed");
+
+    let local_addr = stream.local_addr().unwrap();
+    assert_eq!(local_addr.cid(), libc::VMADDR_CID_ANY);
+
+    let peer_addr = stream.peer_addr().unwrap();
+    assert_eq!(peer_addr.cid(), SERVER_CID);
+    assert_eq!(peer_addr.port(), SERVER_PORT);
 }


### PR DESCRIPTION
This removes a bunch of unsafe blocks and error-checking code.

Also added tests for `local_addr` and `peer_addr` methods.