### PR TITLE
Use nix wrappers for getpeername and getsockname.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 exclude = ["test_fixture"]
 
 [dependencies]
-libc = "0.2.79"
-nix = "0.24.1"
+libc = "0.2.126"
+nix = "0.24.2"
 
 [dev-dependencies]
 rand = "0.8.3"


### PR DESCRIPTION
These are buggy in nix 0.24.1, so this currently breaks the tests. It should work once https://github.com/nix-rust/nix/pull/1736 is merged and released.