### PR TITLE
release: v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vsock"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["fsyncd", "rust-vsock"]
 description = "Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/vsock-rs"


### PR DESCRIPTION
Bump the major version due to api's updating in #25.

Signed-off-by: Tim Zhang <tim@hyper.sh>