### PR TITLE
release: v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vsock"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["fsyncd", "rust-vsock"]
 description = "Virtio socket support for Rust"
 repository = "https://github.com/rust-vsock/vsock-rs"


### PR DESCRIPTION
Bump the major version due to API change in #41, `nix::sys::socket::AddressFamily` is part of the public API of this crate.